### PR TITLE
include reboot logic for windows install of vagrant

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -48,8 +48,7 @@ default['workstation']['atom_pkg'] = [
 ]
 
 default['workstation']['choco_pkgs'] = [
-  '7zip.install',
-  'habitat',
+  '7zip',
   'adobereader',
   'atom',
   'conemu',
@@ -65,7 +64,6 @@ default['workstation']['choco_pkgs'] = [
   'putty',
   'slack',
   'steam',
-  'vagrant',
   'vlc',
   'windirstat',
   'winscp',

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'you@example.com'
 license 'All Rights Reserved'
 description 'Installs/Configures workstation'
 long_description 'Installs/Configures workstation'
-version '0.1.10'
+version '0.2.1'
 chef_version '>= 13.0'
 
 # The `issues_url` points to the location where issues for this cookbook are

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -5,14 +5,24 @@
 # Copyright:: 2018, The Authors, All Rights Reserved.
 include_recipe 'chocolatey::default'
 
+chocolatey_package 'vagrant' do 
+  action :install
+  returns [0, 3010]
+  notifies :request_reboot, 'reboot[reboot_computer]', :delayed
+end
+
 chocolatey_package 'habitat' do
   action :install
-  version '0.65.0'
+  version '0.66.0'
   options '--force'
 end
 
 node['workstation']['choco_pkgs'].each do |choco_pkgs|
-  package choco_pkg do
+  chocolatey_package choco_pkgs do
     action :install
   end
+end
+
+reboot 'reboot_computer' do
+  action :nothing
 end


### PR DESCRIPTION
this PR breaks out vagrant install into separate resource + adds reboot logic as vagrant requires a reboot on Windows. Also removes vagrant from attributes array and renames 7zip to correct package identifier.